### PR TITLE
Fix: Correct Hellio Messaging API integration and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To manually install hellio-ruby via Rubygems simply gem install:
 Register on https://app.helliomessaging.com/try-hellio and get user details, set them in your ENV VARS
 
 ```ruby
-      client_id            = ENV['HELLIO_MESSAGING_CIENT_ID']
+      client_id            = ENV['HELLIO_MESSAGING_CLIENT_ID']
       application_secret   = ENV['HELLIO_MESSAGING_APPLICATION_SECRET']
       sender_id            = ENV['HELLIO_MESSAGING_SENDER_ID']
 


### PR DESCRIPTION
This commit addresses several issues in the Hellio Messaging Ruby client:

- Corrected API parameter usage:
    - Ensured the `mobile_number` argument is used instead of a hardcoded value.
    - Aligned `authKey` generation with API docs (includes hour in timestamp).
    - Switched to JSON POST requests with `Content-Type: application/json`.
    - Updated request parameter names to match API spec (`clientId`, `authKey`, `senderId`, `msisdn`).
- Standardized environment variable name for sender ID to `HELLIO_MESSAGING_SENDER_ID`.
- Added basic error handling for API responses, checking HTTP status codes and raising errors with API-provided messages.
- Removed unused code and improved overall clarity of the request logic.
- Corrected a typo in `README.md` for the `HELLIO_MESSAGING_CLIENT_ID` environment variable.

The library should now function correctly according to the Hellio API v2 documentation.